### PR TITLE
[RFC] Add Node and Edge component forowrdRef

### DIFF
--- a/src/components/Edge.tsx
+++ b/src/components/Edge.tsx
@@ -1,5 +1,6 @@
-import React, { FC, ReactElement } from 'react';
+import React, { ReactElement, forwardRef, useImperativeHandle } from 'react';
 import PropTypes from 'prop-types';
+import gv from 'ts-graphviz';
 import { useEdge, EdgeProps } from '../hooks/use-edge';
 import { useRenderedID } from '../hooks/use-rendered-id';
 
@@ -7,12 +8,13 @@ type Props = Omit<EdgeProps, 'label'> & {
   label?: ReactElement | string;
 };
 
-export const Edge: FC<Props> = ({ children, label, ...props }) => {
+export const Edge = forwardRef<gv.IEdge, Props>(({ children, label, ...props }, ref) => {
   const renderedLabel = useRenderedID(label);
   if (renderedLabel !== undefined) Object.assign(props, { label: renderedLabel });
-  useEdge(props);
+  const edge = useEdge(props);
+  useImperativeHandle(ref, () => edge);
   return <>{children}</>;
-};
+});
 
 Edge.displayName = 'Edge';
 

--- a/src/components/Node.tsx
+++ b/src/components/Node.tsx
@@ -1,5 +1,6 @@
-import React, { FC, ReactElement } from 'react';
+import React, { ReactElement, forwardRef, useImperativeHandle } from 'react';
 import PropTypes from 'prop-types';
+import gv from 'ts-graphviz';
 import { useNode, NodeProps } from '../hooks/use-node';
 import { useRenderedID } from '../hooks/use-rendered-id';
 
@@ -7,12 +8,13 @@ type Props = Omit<NodeProps, 'label'> & {
   label?: ReactElement | string;
 };
 
-export const Node: FC<Props> = ({ children, label, ...props }) => {
+export const Node = forwardRef<gv.INode, Props>(({ children, label, ...props }, ref) => {
   const renderedLabel = useRenderedID(label);
   if (renderedLabel !== undefined) Object.assign(props, { label: renderedLabel });
-  useNode(props);
+  const node = useNode(props);
+  useImperativeHandle(ref, () => node);
   return <>{children}</>;
-};
+});
 
 Node.displayName = 'Node';
 


### PR DESCRIPTION
It was heavy that it was convenient to be able to refer to the Node or Edge instance from the parent component, but I implemented it, but since the instance can be referenced only from inside useEffect after mounting, I felt that it was not practical.

If you have any ideas on how to use it, please let us know.

### Check lists (check `x` in `[ ]` of list items)

- [ ] Test passed
- [ ] Coding style (indentation, etc)
