### PR TITLE
Use dynamic import wasm module

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ $ npm install @ts-graphviz/react
 
 ### Peer Dependencies
 
-- [React](https://github.com/facebook/react/)(>=16.8)
+- [React and ReactDOM](https://github.com/facebook/react/)(>=16.8)
 - [ts-graphviz](https://github.com/ts-graphviz/ts-graphviz)
 - [@hpcc-js/wasm](https://www.npmjs.com/package/@hpcc-js/wasm) (Optional)
 
 ```bash
 # Peer Dependencies
-$ yarn add react ts-graphviz
+$ yarn add react react-dom ts-graphviz
 # Optional Peer Dependencies
-$ yarn add @hpcc-js/wasm react-dom
+$ yarn add @hpcc-js/wasm
 ```
 
 ## DEMO

--- a/rollup.build.ts
+++ b/rollup.build.ts
@@ -22,6 +22,7 @@ async function build({
       typescript({
         tsconfigOverride: {
           compilerOptions: {
+            module: 'ESNext',
             declaration,
           },
         },

--- a/src/hooks/use-rendered.ts
+++ b/src/hooks/use-rendered.ts
@@ -1,5 +1,4 @@
-import { useState, useEffect } from 'react';
-import { graphviz } from '@hpcc-js/wasm';
+import { useState, useEffect, useMemo } from 'react';
 
 export type Format = 'svg' | 'dot' | 'json' | 'dot_json' | 'xdot_json';
 
@@ -24,11 +23,9 @@ export const useRendered = (
   },
 ): string | undefined => {
   const [rendered, setRendered] = useState<string>();
+  const graphviz = useMemo(() => import('@hpcc-js/wasm').then(wasm => wasm.graphviz), []);
   useEffect(() => {
-    (async (): Promise<void> => {
-      const result = await graphviz.layout(dot, format, engine, ext);
-      setRendered(result);
-    })();
-  }, [dot, engine, format, ext, setRendered]);
+    graphviz.then(gv => gv.layout(dot, format, engine, ext)).then(setRendered);
+  }, [dot, engine, format, ext, setRendered, graphviz]);
   return rendered;
 };


### PR DESCRIPTION
### What was a problem

Even if `@hpcc-js/wasm` was not used, it was imported, and it became virtually mandatory even though it was optional peerDependencies.

### How this PR fixes the problem

Fixed by using dynamic import so that it does not depend unless used.

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)
