### PR TITLE
stop running CI on Windows

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         node-version: [10.x, 12.x]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
To temporarily avoid the problem that Graphviz for Windows is experiencing with the 2.44 version. #240
