### PR TITLE
Support grouped edge targets

### DIFF
--- a/src/hooks/__tests__/use-edge.spec.ts
+++ b/src/hooks/__tests__/use-edge.spec.ts
@@ -12,8 +12,22 @@ describe('useEdge', () => {
     expect(result.current).toBeInstanceOf(Edge);
   });
 
+  it('returns an Edge instance in a digraph wrapper for grouped edge targets', () => {
+    const { result } = renderHook(() => useEdge({ targets: ['a', ['b1', 'b2'], 'c'] }), {
+      wrapper: digraph(),
+    });
+    expect(result.current).toBeInstanceOf(Edge);
+  });
+
   it('returns Edge instance in graph wrapper', () => {
     const { result } = renderHook(() => useEdge({ targets: ['a', 'b'] }), {
+      wrapper: graph(),
+    });
+    expect(result.current).toBeInstanceOf(Edge);
+  });
+
+  it('returns an Edge instance in a graph wrapper for grouped edge targets', () => {
+    const { result } = renderHook(() => useEdge({ targets: ['a', ['b1', 'b2'], 'c'] }), {
       wrapper: graph(),
     });
     expect(result.current).toBeInstanceOf(Edge);

--- a/src/hooks/use-edge.ts
+++ b/src/hooks/use-edge.ts
@@ -1,12 +1,12 @@
 import { useEffect, useMemo } from 'react';
-import { EdgeTargetLike, IEdge, EdgeAttributes } from 'ts-graphviz';
+import { EdgeTargetLike, EdgeTargetsLike, IEdge, EdgeAttributes } from 'ts-graphviz';
 import { useCluster } from './use-cluster';
 import { EdgeTargetLengthErrorMessage } from '../utils/errors';
 import { useHasComment } from './use-comment';
 import { useHasAttributes } from './use-has-attributes';
 
 export type EdgeProps = {
-  targets: EdgeTargetLike[];
+  targets: (EdgeTargetLike | EdgeTargetsLike)[];
   comment?: string;
 } & EdgeAttributes;
 


### PR DESCRIPTION
### What was a problem

グループ化されたEdgeターゲットをdot言語に変換できるように対応しました。

### How this PR fixes the problem

グループ化されたEdgeターゲットをdot言語に変換できるようになります。

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)

### Additional Comments (if any)
resolve #104
![-zsh](https://user-images.githubusercontent.com/53528726/107160849-1cb0c300-69dc-11eb-9a26-a6ab90e99509.png)

