### PR TITLE
Remove duplicate code in use digraph file

### DIFF
--- a/src/hooks/__tests__/use-digraph.spec.ts
+++ b/src/hooks/__tests__/use-digraph.spec.ts
@@ -10,4 +10,33 @@ describe('useDigraph', () => {
     });
     expect(result.current).toBeInstanceOf(Digraph);
   });
+
+  it('props comment is changed correctly', () => {
+    const { result } = renderHook(() => useDigraph({ comment: 'some comment' }), {
+      wrapper: context(),
+    });
+    expect(result.current.comment).toBe('some comment');
+  });
+
+  it('props attributes edge is changed correctly', () => {
+    const { result } = renderHook(() => useDigraph({ edge: { color: 'blue', fontcolor: 'blue' } }), {
+      wrapper: context(),
+    });
+    expect(result.current.attributes.edge.get('color')).toBe('blue');
+    expect(result.current.attributes.edge.get('fontcolor')).toBe('blue');
+  });
+
+  it('props attributes node is changed correctly', () => {
+    const { result } = renderHook(() => useDigraph({ node: { shape: 'none' } }), {
+      wrapper: context(),
+    });
+    expect(result.current.attributes.node.get('shape')).toBe('none');
+  });
+
+  it('props attributes graph is changed correctly', () => {
+    const { result } = renderHook(() => useDigraph({ graph: { bgcolor: 'white' } }), {
+      wrapper: context(),
+    });
+    expect(result.current.attributes.graph.get('bgcolor')).toBe('white');
+  });
 });

--- a/src/hooks/use-digraph.ts
+++ b/src/hooks/use-digraph.ts
@@ -1,8 +1,7 @@
 import { useMemo, useEffect } from 'react';
 import { Digraph, RootClusterAttributes } from 'ts-graphviz';
 import { useGraphvizContext } from './use-graphviz-context';
-import { useClusterAttributes, ClusterAttributesProps } from './use-cluster-attributes';
-import { useHasComment } from './use-comment';
+import { ClusterAttributesProps } from './use-cluster-attributes';
 
 export type DigraphProps = {
   id?: string;
@@ -21,9 +20,7 @@ export const useDigraph = ({ id, comment, edge, node, graph, ...attributes }: Di
     g.attributes.edge.apply(edge ?? {});
     g.attributes.graph.apply(graph ?? {});
     return g;
-  }, [context, id, comment, edge, node, graph, attributes]);
-  useHasComment(digraph, comment);
-  useClusterAttributes(digraph, attributes, { edge, node, graph });
+  }, [context,x id, comment, edge, node, graph, attributes]);
   useEffect(() => {
     return (): void => {
       context.root = undefined;

--- a/src/hooks/use-digraph.ts
+++ b/src/hooks/use-digraph.ts
@@ -20,7 +20,7 @@ export const useDigraph = ({ id, comment, edge, node, graph, ...attributes }: Di
     g.attributes.edge.apply(edge ?? {});
     g.attributes.graph.apply(graph ?? {});
     return g;
-  }, [context,x id, comment, edge, node, graph, attributes]);
+  }, [context, id, comment, edge, node, graph, attributes]);
   useEffect(() => {
     return (): void => {
       context.root = undefined;


### PR DESCRIPTION
### What was a problem

Duplicate code in `use-digraph`

### How this PR fixes the problem

Eliminates duplicate code in `use-digraph`

### Check lists (check `x` in `[ ]` of list items)

- [x] Test passed
- [x] Coding style (indentation, etc)

### Additional Comments (if any)
fix #261
![use-digraph_ts_—_react](https://user-images.githubusercontent.com/53528726/109961150-f35e2b00-7d2c-11eb-8f83-05d997a370fd.png)

